### PR TITLE
keep public assets out of serverless function bundles

### DIFF
--- a/lib/meta/og.ts
+++ b/lib/meta/og.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-import { promises as fs } from 'node:fs'
 import type { Metadata } from 'next'
 
 const SITE_NAME = 'Tri-Cities Vote'
@@ -11,28 +9,15 @@ function toAbsoluteUrl(pathname: string) {
   return new URL(pathname, BASE_URL).toString()
 }
 
-async function resolveImageUrl(relativePath?: string | null) {
+function resolveImageUrl(relativePath?: string | null) {
   if (!relativePath) {
     return toAbsoluteUrl(FALLBACK_IMAGE)
   }
 
+  // public/ assets are served from the CDN and deliberately excluded from
+  // function bundles, so the path can't be checked on disk here; trust it.
   const sanitized = relativePath.replace(/^\/+/, '')
-
-  // All images should be checked in filesystem (even OG images are pre-generated PNGs)
-  const target = path.join(process.cwd(), 'public', sanitized)
-
-  try {
-    await fs.access(target)
-    return toAbsoluteUrl(`/${sanitized}`)
-  } catch {
-    // In production, OG images might not exist yet if build failed
-    // Still return the path so it can be generated on-demand
-    if (sanitized.startsWith('og/')) {
-      console.warn(`OG image not found at ${target}, using path anyway: /${sanitized}`)
-      return toAbsoluteUrl(`/${sanitized}`)
-    }
-    return toAbsoluteUrl(FALLBACK_IMAGE)
-  }
+  return toAbsoluteUrl(`/${sanitized}`)
 }
 
 interface CreateOgMetadataOptions {
@@ -51,7 +36,7 @@ export async function createOgMetadata({
   type = 'website'
 }: CreateOgMetadataOptions): Promise<Metadata> {
   const metaDescription = description ?? DEFAULT_DESCRIPTION
-  const imageUrl = await resolveImageUrl(imagePath)
+  const imageUrl = resolveImageUrl(imagePath)
   const canonicalUrl = toAbsoluteUrl(canonicalPath)
 
   return {

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,13 @@ const nextConfig = {
   // We'll start with these basic settings
   reactStrictMode: true,
   swcMinify: true,
+  experimental: {
+    // public/ is served from the CDN; keep its ~280MB of images out of
+    // serverless function bundles (Vercel caps functions at 250MB)
+    outputFileTracingExcludes: {
+      '*': ['./public/**']
+    }
+  },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: '**' },


### PR DESCRIPTION
Production deploys were failing: the [year]/candidate/[slug] function was 281MB uncompressed (Vercel cap is 250MB) because public/ images were traced into every function bundle. This excludes public/ from function tracing; assets are served from the CDN. Preview build confirms functions drop to ~15MB.

Fixes the missing candidate images on tricitiesvote.com/2026/guide/benton-county — prod was stuck on the last successful (pre-pamphlet-import) build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)