### PR TITLE
Pick-2 comparer for open answers; remove A/B midline on 5-point grids

### DIFF
--- a/components/compare/CompareQuestionnaires.tsx
+++ b/components/compare/CompareQuestionnaires.tsx
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/db'
-import { CandidateImage } from '@/components/candidate/CandidateImage'
 import { slugify } from '@/lib/utils'
 import { CompareCandidateStatement } from './CompareCandidateStatement'
+import { QuestionnaireOpenAnswers } from './QuestionnaireOpenAnswers'
 
 interface CompareQuestionnairesProps {
   year: number
@@ -184,44 +184,27 @@ export async function CompareQuestionnaires({ year, regionId, candidates, hidden
             </summary>
 
             {!hideOpenQuestions && section.openQuestions.length > 0 && (
-              <div className="questionnaire-open">
-                {section.openQuestions.map(question => (
-                  <div key={question.id} className="questionnaire-open-block">
-                    <div className="questionnaire-open-question-cell">
-                      <h3>{question.question}</h3>
-                    </div>
-                    <div className={`questionnaire-open-answer-list columns-${Math.min(orderedCandidates.length, 6)}`}>
-                      {orderedCandidates
-                        .filter(candidate => section.responderIds.has(candidate.id))
-                        .map(candidate => {
-                          const answer = question.responses[candidate.id]
-                          const candidateUrl = `/${year}/candidate/${candidate.slug}`
-                          const cardClass = `questionnaire-open-answer-card candidate-card${answer ? '' : ' questionnaire-open-answer-empty'}`
-
-                          return (
-                            <div key={candidate.id} className={cardClass}>
-                              <div className="candidate-card-heading">
-                                <CandidateImage name={candidate.name} image={candidate.image} url={candidateUrl} size={38} />
-                                <h4>{candidate.name}</h4>
-                              </div>
-                              <div className="candidate-card-body candidate-card-body-answer">
-                                {answer ? (
-                                  <p className="candidate-card-text">{answer}</p>
-                                ) : (
-                                  <span className="questionnaire-open-answer-none">—</span>
-                                )}
-                              </div>
-                            </div>
-                          )
-                        })}
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <QuestionnaireOpenAnswers
+                year={year}
+                questions={section.openQuestions.map(question => ({ id: question.id, question: question.question }))}
+                respondents={orderedCandidates
+                  .filter(candidate =>
+                    section.openQuestions.some(question => question.responses[candidate.id])
+                  )
+                  .map(candidate => ({
+                    id: candidate.id,
+                    name: candidate.name,
+                    image: candidate.image ?? null,
+                    slug: candidate.slug,
+                  }))}
+                answers={Object.fromEntries(
+                  section.openQuestions.map(question => [question.id, question.responses])
+                )}
+              />
             )}
 
             {section.abRows.length > 0 && (
-              <div className="compare-table legacy-compare">
+              <div className={`compare-table legacy-compare${section.scale === 5 ? ' scale-5' : ''}`}>
                 <table>
                   <thead>
                     <tr className="key">

--- a/components/compare/QuestionnaireOpenAnswers.tsx
+++ b/components/compare/QuestionnaireOpenAnswers.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useState } from 'react'
+import { CandidateImage } from '@/components/candidate/CandidateImage'
+
+interface OpenQuestion {
+  id: string
+  question: string
+}
+
+interface Respondent {
+  id: string
+  name: string
+  image: string | null
+  slug: string
+}
+
+interface QuestionnaireOpenAnswersProps {
+  year: number
+  questions: OpenQuestion[]
+  respondents: Respondent[]
+  // questionId -> candidateId -> answer text
+  answers: Record<string, Record<string, string>>
+}
+
+function lastName(name: string): string {
+  const parts = name.replace(/"[^"]*"/g, '').trim().split(/\s+/)
+  return parts[parts.length - 1] ?? name
+}
+
+export function QuestionnaireOpenAnswers({ year, questions, respondents, answers }: QuestionnaireOpenAnswersProps) {
+  const usePicker = respondents.length > 2
+  const [selected, setSelected] = useState<string[]>(respondents.slice(0, 2).map(r => r.id))
+
+  if (questions.length === 0 || respondents.length === 0) {
+    return null
+  }
+
+  const visible = usePicker
+    ? respondents.filter(r => selected.includes(r.id))
+    : respondents
+
+  const selectCandidate = (id: string) => {
+    if (selected.includes(id)) {
+      return
+    }
+    // Rotate: the earlier selection leaves, the newcomer joins.
+    setSelected([selected[1], id].filter(Boolean) as string[])
+  }
+
+  return (
+    <div className="questionnaire-open">
+      {usePicker && (
+        <div className="questionnaire-open-picker" role="group" aria-label="Choose two candidates to compare">
+          <p className="questionnaire-open-picker-hint">Pick two to compare:</p>
+          <ul className="questionnaire-open-picker-rail">
+            {respondents.map(candidate => {
+              const isSelected = selected.includes(candidate.id)
+              return (
+                <li key={candidate.id}>
+                  <button
+                    type="button"
+                    className={`questionnaire-open-picker-chip${isSelected ? ' is-selected' : ''}`}
+                    aria-pressed={isSelected}
+                    onClick={() => selectCandidate(candidate.id)}
+                  >
+                    <span className="questionnaire-open-picker-face">
+                      {candidate.image ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={candidate.image} alt="" width={34} height={34} />
+                      ) : (
+                        <span className="questionnaire-open-picker-initials">
+                          {candidate.name.split(' ').map(part => part[0]).join('').toUpperCase()}
+                        </span>
+                      )}
+                    </span>
+                    <span className="questionnaire-open-picker-name">{lastName(candidate.name)}</span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+
+      {questions.map(question => (
+        <div key={question.id} className="questionnaire-open-block">
+          <div className="questionnaire-open-question-cell">
+            <h3>{question.question}</h3>
+          </div>
+          <div className={`questionnaire-open-answer-list columns-${Math.min(visible.length, 6)}`}>
+            {visible.map(candidate => {
+              const answer = answers[question.id]?.[candidate.id]
+              const candidateUrl = `/${year}/candidate/${candidate.slug}`
+              const cardClass = `questionnaire-open-answer-card candidate-card${answer ? '' : ' questionnaire-open-answer-empty'}`
+
+              return (
+                <div key={candidate.id} className={cardClass}>
+                  <div className="candidate-card-heading">
+                    <CandidateImage name={candidate.name} image={candidate.image} url={candidateUrl} size={38} />
+                    <h4>{candidate.name}</h4>
+                  </div>
+                  <div className="candidate-card-body candidate-card-body-answer">
+                    {answer ? (
+                      <p className="candidate-card-text">{answer}</p>
+                    ) : (
+                      <span className="questionnaire-open-answer-none">—</span>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3759,6 +3759,81 @@ details.questionnaire-compare-section[open] > summary .questionnaire-compare-hea
   content: '▾ ';
 }
 
+/* The global nth-child(3)/(4) borders draw the A/B midline for 4-point
+   grids; a 5-point grid has Neutral as its middle, so no divider. */
+.legacy-compare.scale-5 td:nth-child(3),
+.legacy-compare.scale-5 th:nth-child(3) {
+  border-right: 0;
+}
+
+.legacy-compare.scale-5 td:nth-child(4),
+.legacy-compare.scale-5 th:nth-child(4) {
+  border-left: 1px solid #eee;
+}
+
+.questionnaire-open-picker {
+  margin-bottom: 1.5rem;
+}
+
+.questionnaire-open-picker-hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.9em;
+  font-weight: 600;
+  color: #4b6b7a;
+}
+
+.questionnaire-open-picker-rail {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.questionnaire-open-picker-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px 4px 4px;
+  border: 1px solid #cde4e4;
+  border-radius: 999px;
+  background: #fff;
+  font: inherit;
+  font-size: 0.9em;
+  color: #234;
+  cursor: pointer;
+}
+
+.questionnaire-open-picker-chip:hover {
+  border-color: #53bce4;
+}
+
+.questionnaire-open-picker-chip.is-selected {
+  border-color: #0066cc;
+  background: #e1f2fc;
+  font-weight: 600;
+}
+
+.questionnaire-open-picker-face img,
+.questionnaire-open-picker-initials {
+  display: block;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.questionnaire-open-picker-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e4f5f5;
+  color: #4b6b7a;
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .questionnaire-source {
   margin: 0 0 1.5rem;
   font-size: 0.9em;


### PR DESCRIPTION
Follow-up to #195 based on the WA-04 page review.

- Open answers with more than 2 respondents now render a chip rail (face + name); exactly two candidates show side-by-side in the familiar 1+1 columns, and clicking another chip rotates out the older selection. Races with ≤2 respondents keep the static layout, so general-election pages are unchanged. One rail controls all open questions in a section.
- The global 8px A/B midline border no longer draws on 5-point grids, where Neutral is the middle.

Verified in-browser: chip rotation works, Valencia+Sessler side-by-side, no separator between Lean A and Neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)