### PR TITLE
Surveys page, avatar centering, 3-column compare picker

### DIFF
--- a/app/[year]/compare/[slug]/page.tsx
+++ b/app/[year]/compare/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import { cache, type CSSProperties } from 'react'
+import { prisma } from '@/lib/db'
 import { getGuidesForYear, getRaceByYearAndSlug } from '@/lib/queries'
 import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
 import { calculateFundraising } from '@/lib/calculateFundraising'
 import { slugify } from '@/lib/utils'
 import { CompareTable, type ComparisonRow } from '@/components/compare/CompareTable'
-import { CompareQuestionnaires } from '@/components/compare/CompareQuestionnaires'
 import { CompareSelectionProvider, SelectableCompareCard } from '@/components/compare/CompareSelection'
 import { buildBreadcrumbs } from '@/lib/officeDisplay'
 import { preferWikiString } from '@/lib/wiki/utils'
@@ -279,18 +279,25 @@ export default async function ComparePage({ params }: ComparePageProps) {
     },
   ]
 
-  const questionnaireCandidates = candidateCards.map(card => ({
-    id: card.id,
-    name: card.displayName,
-    image: card.image,
-    slug: card.slug,
-  }))
-
   const rowsToRender = isBallotMeasure
     ? compareCardRows.filter(row => row.key !== 'engagement')
     : compareCardRows
 
   const usePicker = !isBallotMeasure && candidateCards.length > 2
+
+  const surveys = isBallotMeasure
+    ? []
+    : await prisma.questionnaire.findMany({
+        where: {
+          year,
+          hidden: false,
+          responses: {
+            some: { candidateId: { in: candidateCards.map(card => card.id) } },
+          },
+        },
+        select: { id: true, title: true, sourceName: true, official: true },
+        orderBy: { title: 'asc' },
+      })
 
   const comparisonBody = (
     <>
@@ -318,13 +325,25 @@ export default async function ComparePage({ params }: ComparePageProps) {
         </div>
       )}
 
-      {!isBallotMeasure && (
-        <CompareQuestionnaires
-          year={year}
-          regionId={raceWithRelations.office.regionId}
-          candidates={questionnaireCandidates}
-          hiddenTitles={triCitiesStatus.hiddenTitles}
-        />
+      {surveys.length > 0 && (
+        <div className="questionnaire-link-card">
+          <h2>Candidate surveys</h2>
+          <ul>
+            {surveys.map(survey => (
+              <li key={survey.id}>
+                {survey.title}
+                {!survey.official && survey.sourceName && (
+                  <span className="questionnaire-link-source"> — by {survey.sourceName}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+          <p>
+            <Link href={`/${year}/questionnaires/${params.slug}`}>
+              See how the candidates answered →
+            </Link>
+          </p>
+        </div>
       )}
     </>
   )

--- a/app/[year]/compare/[slug]/page.tsx
+++ b/app/[year]/compare/[slug]/page.tsx
@@ -283,7 +283,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
     ? compareCardRows.filter(row => row.key !== 'engagement')
     : compareCardRows
 
-  const usePicker = !isBallotMeasure && candidateCards.length > 2
+  const usePicker = !isBallotMeasure && candidateCards.length > 3
 
   const surveys = isBallotMeasure
     ? []

--- a/app/[year]/questionnaires/[slug]/page.tsx
+++ b/app/[year]/questionnaires/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function QuestionnairePage({ params }: QuestionnairePagePro
   })
   breadcrumbs.push({ label: 'Surveys', url: `/${year}/questionnaires/${params.slug}` })
 
-  const usePicker = questionnaireCandidates.length > 2
+  const usePicker = questionnaireCandidates.length > 3
 
   const body = (
     <>

--- a/app/[year]/questionnaires/[slug]/page.tsx
+++ b/app/[year]/questionnaires/[slug]/page.tsx
@@ -1,0 +1,165 @@
+import { cache } from 'react'
+import { getGuidesForYear, getRaceByYearAndSlug } from '@/lib/queries'
+import { notFound, redirect } from 'next/navigation'
+import Link from 'next/link'
+import { slugify } from '@/lib/utils'
+import { CompareQuestionnaires } from '@/components/compare/CompareQuestionnaires'
+import { CompareSelectionProvider } from '@/components/compare/CompareSelection'
+import { buildBreadcrumbs } from '@/lib/officeDisplay'
+import { preferWikiString } from '@/lib/wiki/utils'
+import { evaluateTriCitiesRaceStatus } from '@/lib/triCitiesVote'
+import { CURRENT_ELECTION_YEAR } from '@/lib/constants'
+import { createOgMetadata } from '@/lib/meta/og'
+
+interface QuestionnairePageProps {
+  params: {
+    year: string
+    slug: string
+  }
+}
+
+const getRaceCached = cache(async (year: number, slug: string) => getRaceByYearAndSlug(year, slug))
+
+export const revalidate = 3600
+
+export async function generateStaticParams() {
+  const year = CURRENT_ELECTION_YEAR
+  const guides = await getGuidesForYear(year)
+  const seen = new Set<string>()
+  const params: Array<{ year: string; slug: string }> = []
+
+  for (const guide of guides) {
+    for (const race of guide.Race) {
+      const raceSlug = slugify(race.office.title)
+      if (!seen.has(raceSlug)) {
+        seen.add(raceSlug)
+        params.push({ year: String(year), slug: raceSlug })
+      }
+    }
+  }
+
+  return params
+}
+
+export async function generateMetadata({ params }: QuestionnairePageProps) {
+  const year = Number.parseInt(params.year, 10)
+
+  if (!Number.isFinite(year) || year !== CURRENT_ELECTION_YEAR) {
+    return createOgMetadata({
+      title: 'Tri-Cities Vote',
+      canonicalPath: '/',
+      description: 'Nonpartisan voter guides for Tri-Cities elections'
+    })
+  }
+
+  const race = await getRaceCached(year, params.slug)
+
+  if (!race) {
+    notFound()
+  }
+
+  const displayTitle = preferWikiString(race.office as any, 'title') ?? race.office.title
+
+  return createOgMetadata({
+    title: `${displayTitle} • ${year} Candidate Surveys`,
+    description: `Questionnaire and survey responses from candidates in the ${displayTitle} race.`,
+    canonicalPath: `/${year}/questionnaires/${params.slug}`
+  })
+}
+
+export default async function QuestionnairePage({ params }: QuestionnairePageProps) {
+  const year = Number.parseInt(params.year, 10)
+
+  if (!Number.isFinite(year) || year !== CURRENT_ELECTION_YEAR) {
+    redirect('/')
+  }
+
+  const race = await getRaceCached(year, params.slug)
+
+  if (!race) {
+    notFound()
+  }
+
+  const raceWithRelations = race as any
+  const triCitiesStatus = evaluateTriCitiesRaceStatus(raceWithRelations, year)
+  const guide = raceWithRelations.Guide?.[0]
+
+  const visibleCandidates = (Array.isArray(raceWithRelations.candidates)
+    ? (raceWithRelations.candidates as Array<{ candidate: any }>)
+    : []
+  ).filter(({ candidate }) => !candidate.hide)
+
+  const questionnaireCandidates = visibleCandidates.map(({ candidate }: { candidate: any }) => ({
+    id: candidate.id,
+    name: preferWikiString(candidate as any, 'name') ?? candidate.name,
+    image: preferWikiString(candidate as any, 'image') ?? candidate.image ?? null,
+    slug: slugify(candidate.name),
+  }))
+
+  const displayTitle = preferWikiString(raceWithRelations.office as any, 'title') ?? raceWithRelations.office.title
+
+  const breadcrumbs = buildBreadcrumbs({
+    year,
+    region: guide?.region,
+    office: raceWithRelations.office,
+  })
+  breadcrumbs.push({ label: 'Surveys', url: `/${year}/questionnaires/${params.slug}` })
+
+  const usePicker = questionnaireCandidates.length > 2
+
+  const body = (
+    <>
+      <div className="questionnaire-page-intro">
+        <p>
+          Some of the surveys below were created and conducted by independent community
+          organizations, not by Tri-Cities Vote — each one names the group behind it.
+          We publish them as a public service.
+        </p>
+        <p>
+          Does your organization survey candidates?{' '}
+          <a href="mailto:guide@tricitiesvote.com">Send it to us</a> and we&apos;ll include it.
+        </p>
+      </div>
+
+      <CompareQuestionnaires
+        year={year}
+        regionId={raceWithRelations.office.regionId}
+        candidates={questionnaireCandidates}
+        hiddenTitles={triCitiesStatus.hiddenTitles}
+      />
+    </>
+  )
+
+  return (
+    <>
+      <nav className="breadcrumb">
+        {breadcrumbs.map((crumb, index) => (
+          <span key={`${crumb.label}-${index}`}>
+            {index > 0 && ' » '}
+            {crumb.url ? <Link href={crumb.url}>{crumb.label}</Link> : crumb.label}
+          </span>
+        ))}
+      </nav>
+
+      <div className="guide">
+        <section className="race race-compare questionnaire-page">
+          <h1 className="race-title">Candidate Surveys — {displayTitle}</h1>
+
+          {usePicker ? (
+            <CompareSelectionProvider
+              candidates={questionnaireCandidates.map(candidate => ({
+                id: candidate.id,
+                name: candidate.name,
+                image: candidate.image,
+              }))}
+            >
+              {body}
+            </CompareSelectionProvider>
+          ) : (
+            body
+          )}
+        </section>
+      </div>
+    </>
+  )
+}

--- a/components/compare/CompareQuestionnaires.tsx
+++ b/components/compare/CompareQuestionnaires.tsx
@@ -49,6 +49,7 @@ type QuestionnaireRecord = {
   scale: number
   sourceName: string | null
   sourceUrl: string | null
+  official: boolean
   questions: Array<{
     id: string
     type: string
@@ -78,6 +79,7 @@ interface QuestionnaireSection {
   scale: number
   sourceName: string | null
   sourceUrl: string | null
+  official: boolean
   abRows: AbRow[]
   openQuestions: OpenQuestion[]
   responderIds: Set<string>
@@ -155,6 +157,7 @@ export async function CompareQuestionnaires({ year, regionId, candidates, hidden
       (section.abRows.length > 0 || section.openQuestions.length > 0) &&
       !hiddenTitleSet.has(section.title)
     )
+    .sort((a, b) => Number(b.official) - Number(a.official))
 
   if (sections.length === 0) {
     return null
@@ -171,16 +174,19 @@ export async function CompareQuestionnaires({ year, regionId, candidates, hidden
           <details key={section.id} className="questionnaire-compare-section" open={!collapsed}>
             <summary>
               <h2 id="tcv" className="questionnaire-compare-heading">{section.title}</h2>
-              {section.sourceName && (
+              {section.official ? (
+                <p className="questionnaire-source">A Tri-Cities Vote questionnaire</p>
+              ) : section.sourceName ? (
                 <p className="questionnaire-source">
                   Survey by{' '}
                   {section.sourceUrl ? (
                     <a href={section.sourceUrl}>{section.sourceName}</a>
                   ) : (
                     section.sourceName
-                  )}
+                  )}{' '}
+                  — an independent community organization
                 </p>
-              )}
+              ) : null}
             </summary>
 
             {!hideOpenQuestions && section.openQuestions.length > 0 && (
@@ -351,6 +357,7 @@ function buildSection(
     scale,
     sourceName: questionnaire.sourceName,
     sourceUrl: questionnaire.sourceUrl,
+    official: questionnaire.official,
     abRows,
     openQuestions,
     responderIds,

--- a/components/compare/CompareSelection.tsx
+++ b/components/compare/CompareSelection.tsx
@@ -8,9 +8,10 @@ export interface CompareSelectionCandidate {
   image: string | null
 }
 
+export const MAX_COMPARE_SELECTION = 3
+
 interface CompareSelectionState {
   left: string | null
-  right: string | null
   isVisible: (candidateId: string) => boolean
   orderedVisibleIds: string[]
 }
@@ -32,44 +33,38 @@ interface CompareSelectionProviderProps {
 }
 
 // Nothing is shown until chips are clicked. The first selection becomes the
-// pinned left-column reference; the second fills the right column, and
-// further clicks swap the right side so you can walk the field against your
-// pick. Clicking a shown candidate removes them.
+// pinned left-column reference; later selections fill up to three columns,
+// and once full, further clicks swap the rightmost slot so you can walk the
+// field against your picks. Clicking a shown candidate removes them.
 export function CompareSelectionProvider({ candidates, children }: CompareSelectionProviderProps) {
-  const [left, setLeft] = useState<string | null>(null)
-  const [right, setRight] = useState<string | null>(null)
+  const [selected, setSelected] = useState<string[]>([])
 
   const selectCandidate = (id: string) => {
-    if (id === left) {
-      setLeft(right)
-      setRight(null)
+    if (selected.includes(id)) {
+      setSelected(selected.filter(entry => entry !== id))
       return
     }
-    if (id === right) {
-      setRight(null)
+    if (selected.length < MAX_COMPARE_SELECTION) {
+      setSelected([...selected, id])
       return
     }
-    if (left === null) {
-      setLeft(id)
-      return
-    }
-    setRight(id)
+    setSelected([...selected.slice(0, MAX_COMPARE_SELECTION - 1), id])
   }
 
-  const visibleCount = [left, right].filter(Boolean).length
+  const visibleCount = selected.length
+  const left = selected[0] ?? null
 
   const state: CompareSelectionState = {
     left,
-    right,
-    isVisible: id => id === left || id === right,
-    orderedVisibleIds: [left, right].filter(Boolean) as string[],
+    isVisible: id => selected.includes(id),
+    orderedVisibleIds: selected,
   }
 
-  const hint = left === null
+  const hint = selected.length === 0
     ? 'Click a candidate to start comparing:'
-    : right === null
-      ? 'Pinned to the left column — click another candidate to compare side by side.'
-      : 'Click other candidates to swap the right side; click a selected one to remove them.'
+    : selected.length < MAX_COMPARE_SELECTION
+      ? 'Click more candidates to compare up to three side by side; click a selected one to remove them.'
+      : 'Comparing three — click another candidate to swap the rightmost, or click a selected one to remove them.'
 
   return (
     <CompareSelectionContext.Provider value={state}>
@@ -82,7 +77,7 @@ export function CompareSelectionProvider({ candidates, children }: CompareSelect
           <ul className="compare-selection-rail">
             {candidates.map(candidate => {
               const isPinned = candidate.id === left
-              const isSecond = candidate.id === right
+              const isSecond = selected.includes(candidate.id) && candidate.id !== left
               return (
                 <li key={candidate.id}>
                   <button
@@ -122,7 +117,7 @@ interface SelectableCompareCardProps {
 }
 
 // Client wrapper that hides server-rendered cards outside the selection and
-// keeps the pinned candidate in the left column.
+// arranges columns in selection order (pinned reference first).
 export function SelectableCompareCard({ candidateId, className, children }: SelectableCompareCardProps) {
   const selection = useCompareSelection()
 
@@ -130,10 +125,10 @@ export function SelectableCompareCard({ candidateId, className, children }: Sele
     return null
   }
 
-  const isLeft = selection?.left === candidateId
+  const position = selection ? selection.orderedVisibleIds.indexOf(candidateId) : -1
 
   return (
-    <div className={className} style={isLeft ? { order: -1 } : undefined}>
+    <div className={className} style={position >= 0 ? { order: position } : undefined}>
       {children}
     </div>
   )

--- a/components/compare/QuestionnaireOpenAnswers.tsx
+++ b/components/compare/QuestionnaireOpenAnswers.tsx
@@ -34,7 +34,7 @@ export function QuestionnaireOpenAnswers({ year, questions, candidates, responde
   const selection = useCompareSelection()
   const respondentIdSet = new Set(respondentIds)
   const respondents = candidates.filter(candidate => respondentIdSet.has(candidate.id))
-  const usePicker = !selection && respondents.length > 2
+  const usePicker = !selection && respondents.length > 3
   const [selected, setSelected] = useState<string[]>(respondents.slice(0, 2).map(r => r.id))
 
   if (questions.length === 0 || respondents.length === 0) {

--- a/data/questionnaires/README.md
+++ b/data/questionnaires/README.md
@@ -32,6 +32,7 @@ The importer is idempotent: questions upsert by position, responses are deleted 
   "sourceUrl": "https://citizensclimatelobby.org/",    // attribution link (optional)
   "scale": 5,                            // 4 = StrongA/LeanA/LeanB/StrongB, 5 adds Neutral in the middle
   "hidden": false,                       // true = store but never display (optional, default false)
+  "official": false,                     // true = a Tri-Cities Vote questionnaire, not an outside org's (optional)
   "regionName": "Benton County",         // optional; scopes display to a region's guides
   "engagement": {
     "name": "CCL Climate Survey",       // at-a-glance participation row label

--- a/prisma/migrations/20260707081325_questionnaire_official/migration.sql
+++ b/prisma/migrations/20260707081325_questionnaire_official/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Questionnaire" ADD COLUMN     "official" BOOLEAN NOT NULL DEFAULT false;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -215,6 +215,7 @@ model Questionnaire {
   sourceName  String?
   sourceUrl   String?
   hidden      Boolean                @default(false)
+  official    Boolean                @default(false)
 
   region      Region?                @relation(fields: [regionId], references: [id])
   questions   QuestionnaireQuestion[]

--- a/scripts/import/questionnaire-load.ts
+++ b/scripts/import/questionnaire-load.ts
@@ -23,6 +23,7 @@ interface QuestionnaireConfig {
   sourceUrl?: string
   scale: number
   hidden?: boolean
+  official?: boolean
   regionName?: string
   engagement?: { name: string; date?: string }
   coverage: { officeTitles: string[] }
@@ -201,6 +202,7 @@ async function writeQuestionnaire(
       sourceName: config.sourceName ?? null,
       sourceUrl: config.sourceUrl ?? null,
       hidden: config.hidden ?? false,
+      official: config.official ?? false,
       regionId,
     },
     update: {
@@ -210,6 +212,7 @@ async function writeQuestionnaire(
       sourceName: config.sourceName ?? null,
       sourceUrl: config.sourceUrl ?? null,
       hidden: config.hidden ?? false,
+      official: config.official ?? false,
       regionId,
     },
   })
@@ -290,7 +293,7 @@ async function syncEngagement(
   const date = config.engagement.date ? new Date(config.engagement.date) : undefined
   const engagementSlug = generateEngagementSlug(config.engagement.name, date)
   const raceLinkByOffice = new Map(
-    offices.map(o => [o.id, `/${config.year}/compare/${slugify(o.title)}`])
+    offices.map(o => [o.id, `/${config.year}/questionnaires/${slugify(o.title)}`])
   )
   const primaryLink = raceLinkByOffice.get(offices[0].id) ?? `/${config.year}`
   const notes = config.sourceName

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3812,7 +3812,9 @@ details.questionnaire-compare-section[open] > summary .questionnaire-compare-hea
 }
 
 .compare-selection-chip span,
-.questionnaire-open-picker-chip span {
+.compare-selection-chip img,
+.questionnaire-open-picker-chip span,
+.questionnaire-open-picker-chip img {
   margin: 0;
 }
 
@@ -3835,6 +3837,12 @@ details.questionnaire-compare-section[open] > summary .questionnaire-compare-hea
 
 .compare-selection-pin {
   font-size: 0.85em;
+}
+
+.compare-selection-face,
+.questionnaire-open-picker-face {
+  display: flex;
+  align-items: center;
 }
 
 .compare-selection-face img,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3892,6 +3892,55 @@ details.questionnaire-compare-section[open] > summary .questionnaire-compare-hea
   color: #4b6b7a;
 }
 
+.questionnaire-page-intro {
+  margin-bottom: 2rem;
+  padding: 1rem 1.25rem;
+  background: #edfafa;
+  border-radius: 6px;
+  font-size: 0.95em;
+  color: #234;
+}
+
+.questionnaire-page-intro p {
+  margin: 0 0 0.5rem;
+}
+
+.questionnaire-page-intro p:last-child {
+  margin-bottom: 0;
+}
+
+.questionnaire-link-card {
+  margin-top: 2rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid #cde4e4;
+  border-radius: 6px;
+  background: #edfafa;
+}
+
+.questionnaire-link-card h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+  color: #0066cc;
+}
+
+.questionnaire-link-card ul {
+  margin: 0 0 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.questionnaire-link-card li {
+  margin-bottom: 0.25rem;
+}
+
+.questionnaire-link-source {
+  color: #4b6b7a;
+}
+
+.questionnaire-link-card p {
+  margin: 0;
+  font-weight: 600;
+}
+
 .questionnaire-open {
   margin-bottom: 3rem;
   display: grid;


### PR DESCRIPTION
Follow-up to #197 (which merged just before two of these commits landed on the branch).

- Chip avatars properly centered — a global img margin-bottom was pushing them high (this is the fix for the "image smashed up to the top" report).
- Separate candidate surveys page at /2026/questionnaires/[race] with independence framing, "send it to us and we'll include it" invite (guide@tricitiesvote.com), and an official flag distinguishing Tri-Cities Vote questionnaires from independent-org surveys. Compare page swaps the embedded grid for a link card; at-a-glance participation items link to the surveys page.
- Compare picker now allows up to 3 columns; races with 2–3 candidates always show everyone with no picker; chips only appear for 4+ candidate races. Fourth selection swaps the rightmost slot, keeping the pinned reference.

Verified in-browser: 3-candidate race renders all three with no picker; WA-04 walk-through (pin, add two, swap rightmost, remove) behaves per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)